### PR TITLE
Feature/demand prediction

### DIFF
--- a/movi/benchmark_demand_model.py
+++ b/movi/benchmark_demand_model.py
@@ -1,0 +1,118 @@
+import logging
+from typing import Tuple
+import argparse
+import pandas as pd
+import numpy as np
+from shapely.geometry import mapping
+from tools import points_per_cell
+import random
+
+import torch
+import torch.nn as nn
+from torch.utils.data import Dataset, DataLoader, TensorDataset
+from torchvision import transforms
+
+from simobility.utils import read_polygon
+from demand_net import DemandNetMOVI, DemandNet
+from demand_prediction import (DemandDataset,
+                               DemandDatasetMOVI,
+                               DemandDatasetMOVIVariablePlanes,
+                               rmse_loss
+)
+
+"""
+Based on research paper "MOVI: A Model-Free Approach to Dynamic Fleet Management"
+
+Predict demand using CNN where input is total number pickups per cell of a city grid
+("demand image").
+
+TODO: change input a 3D matrix where each image is a demand aggregation for N minuts bucket
+in order to be able to catch some temporal information. Similar to the approach for following
+research paper: https://storage.googleapis.com/deepmind-media/dqn/DQNNaturePaper.pdf
+"""
+
+torch.manual_seed(42)
+torch.cuda.manual_seed(42)
+np.random.seed(42)
+random.seed(42)
+torch.backends.cudnn.deterministic = True
+
+def evaluate_model(model: nn.Module, data_loader):
+    criterion = rmse_loss
+    model.eval()
+    test_loss = []
+
+    with torch.no_grad():
+        for i, (images, labels) in enumerate(data_loader):
+            predicted = model(images)
+
+            labels = labels.view(labels.size(0), -1)
+            loss = criterion(predicted, labels)
+
+            test_loss.append(loss.item())
+
+    print(f'\nTest RMSE={np.mean(test_loss):.4}, RMSE std={np.std(test_loss):.4}')
+
+
+def evaluate_model_MOVI(model: nn.Module, data_loader):
+    criterion = rmse_loss
+    model.eval()
+    test_loss = []
+
+    with torch.no_grad():
+        for i, data in enumerate(data_loader):
+            images,cd,sd,ch,sh,labels = data
+            predicted = model(images,cd,sd,ch,sh)
+
+            labels = labels.view(labels.size(0), -1)
+            loss = criterion(predicted, labels)
+
+            test_loss.append(loss.item())
+
+    print(f'\nTest RMSE={np.mean(test_loss):.4}, RMSE std={np.std(test_loss):.4}')
+    
+def prepare_data_loader(rides, bounding_box, image_shape, batch_size):
+    rides.rename(columns={'tpep_pickup_datetime':'pickup_datetime','pickup_latitude':
+                          'pickup_lat', 'pickup_longitude': 'pickup_lon'}, inplace=True)
+    rides.pickup_datetime = pd.to_datetime(rides['pickup_datetime'])
+
+    rides.pickup_datetime = rides.pickup_datetime.dt.round("10min")
+
+    #TODO: preprocess data!
+
+    #data = DemandDatasetMOVIVariablePlanes(rides, bounding_box, image_shape)
+    #data = DemandDatasetMOVI(rides, bounding_box, image_shape)
+    data = DemandDataset(rides, bounding_box, image_shape)
+    data_loader = DataLoader(data, batch_size=batch_size, shuffle=True)
+
+    return data_loader
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Preprocess data")
+    # NOTE: demand file preprocessed using scripts from simobility
+    parser.add_argument("--model", help="Model file")
+    parser.add_argument("--test-dataset", help="Feather file with trip data")
+    parser.add_argument(
+        "--geofence", help="Geojson file with operational area geometry"
+    )
+    args = parser.parse_args()
+
+    geofence = read_polygon(args.geofence)
+    # lon/lat order
+    bounding_box = geofence.bounds
+
+    test = pd.read_feather(args.test_dataset, use_threads=True)
+    batch_size = 10
+    image_shape = (212, 219)
+
+    test_loader = prepare_data_loader(test, bounding_box, image_shape, batch_size)
+
+    #model = DemandNetMOVI(image_shape)
+    model = DemandNet(image_shape)
+    model.load_state_dict(torch.load(args.model))
+
+    #torch.save(model.state_dict(), 'demand_model_212_219_variable.pth')
+
+    evaluate_model(model, test_loader)
+    #evaluate_model_MOVI(model, test_loader)

--- a/movi/demand_net.py
+++ b/movi/demand_net.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from math import ceil
+from torch import cat
 
 """
 
@@ -83,3 +84,55 @@ class DemandNet(nn.Module):
 def calc_out_size(in_size: int, kernel_size: int, padding: int = 0, stride: int = 1):
     """Calculate output size of any dimention"""
     return ceil((in_size - kernel_size + 2 * padding) / stride + 1)
+
+class DemandNetMOVI(nn.Module):
+
+    """
+    Spatial-temporal demand prediction
+    """
+
+    def __init__(self, input_shape):
+        super(DemandNetMOVI, self).__init__()
+
+        # The first hidden layer convolves 16 filters of 5×5
+        self.conv1 = nn.Conv2d(5, 16, 5)
+        output_shape = (
+            calc_out_size(input_shape[0], 5),
+            calc_out_size(input_shape[1], 5),
+        )
+
+        # The second layers convolves 32 filters of 3×3
+        self.conv2 = nn.Conv2d(16, 32, 3)
+        output_shape = (
+            calc_out_size(output_shape[0], 3),
+            calc_out_size(output_shape[1], 3),
+        )
+        # The final layer convolves 1 filter of kernel size 1×1
+        self.conv3 = nn.Conv2d(32, 1, 1)
+        
+        self.seq = nn.Sequential(
+            self.conv1,
+            self.conv2,
+            self.conv3
+        )
+
+        output_shape = (
+            calc_out_size(output_shape[0], 1),
+            calc_out_size(output_shape[1], 1),
+        )
+
+        self.fc = nn.Linear(output_shape[0] * output_shape[1], 100)
+
+        # back to the original image size
+        self.fc2 = nn.Linear(100, input_shape[0] * input_shape[1])
+
+    def forward(self, x, cd, sd, ch, sh):
+        # Combine the data in 5 layers for the input
+        a = self.seq(cat((x,cd, sd, ch, sh),1))
+        x = F.relu(a)
+        # flatten
+        x = x.view(x.size(0), -1)
+        x = self.fc(x)
+        x = self.fc2(x)
+        
+        return x

--- a/movi/demand_prediction.py
+++ b/movi/demand_prediction.py
@@ -13,7 +13,7 @@ from torch.utils.data import Dataset, DataLoader, TensorDataset
 from torchvision import transforms
 
 from simobility.utils import read_polygon
-from demand_net import DemandNetMOVI
+from demand_net import DemandNetMOVI, DemandNet
 
 """
 Based on research paper "MOVI: A Model-Free Approach to Dynamic Fleet Management"
@@ -390,7 +390,7 @@ def prepare_data_loader(rides, bounding_box, image_shape, batch_size):
 
     #TODO: preprocess data!
 
-    data = DemandDatasetMOVIVariablePlanes(rides, bounding_box, image_shape)
+    data = DemandDataset(rides, bounding_box, image_shape)
     data_loader = DataLoader(data, batch_size=batch_size, shuffle=True)
 
     return data_loader
@@ -419,8 +419,8 @@ if __name__ == "__main__":
     train_loader = prepare_data_loader(train, bounding_box, image_shape, batch_size)
     #test_loader = prepare_data_loader(test, bounding_box, image_shape, batch_size)
 
-    model = train_model_MOVI(train_loader, image_shape)
+    model = train_model(train_loader, image_shape)
 
-    torch.save(model.state_dict(), 'demand_model_212_219_variable.pth')
+    torch.save(model.state_dict(), 'demand_model_212_219_base.pth')
 
     #evaluate_model(model, test_loader)


### PR DESCRIPTION
In this pull request I added to the demand prediction model new inputs those being:

- cos of the hour
- sin of the hour
- cos of the day
- sin of the day

as described in the MOVI paper. The paper proposes adding a constant plane for each feature, I did this and a modification adding a plane of 0s except for the cell where there was a pickup where I compute cos/sin of the feature.

I tested the models fixing the different seeds

```
torch.manual_seed(42)
torch.cuda.manual_seed(42)
np.random.seed(42)
random.seed(42)
torch.backends.cudnn.deterministic = True
```

and compared the results of the already implemented model (`base`), the one proposed by MOVI (`static`) and my modification (`variable`). For training I used the data from yellow taxi, to be exact `yellow_tripdata_2016-06.feather` and for evaluating the model I used the files `yellow_tripdata_2016-03.feather` and `yellow_tripdata_2015-12.feather` those being different years in different moments of the year. The results were:
```
(env) ➜  movi git:(feature/demand-prediction) ✗ python benchmark_demand_model.py --model demand_model_212_219_base.pth --test-dataset /media/yabir/datasets/yellow_tripdata_2016-03.feather --geofence nyc_geofence.geojson
Dataset size: 4464

Test RMSE=0.3257, RMSE std=0.0241
(env) ➜  movi git:(feature/demand-prediction) ✗ 

(env) ➜  movi git:(feature/demand-prediction) ✗ python benchmark_demand_model.py --model demand_model_212_219_static.pth --test-dataset /media/yabir/datasets/yellow_tripdata_2016-03.feather --geofence nyc_geofence.geojson
Dataset size: 4464

Test RMSE=0.3047, RMSE std=0.02379
(env) ➜  movi git:(feature/demand-prediction) ✗ 

(env) ➜  movi git:(feature/demand-prediction) ✗ python benchmark_demand_model.py --model demand_model_212_219_variable.pth --test-dataset /media/yabir/datasets/yellow_tripdata_2016-03.feather --geofence nyc_geofence.geojson
Dataset size: 4464

Test RMSE=0.306, RMSE std=0.02437
(env) ➜  movi git:(feature/demand-prediction) ✗ 
```
```

(env) ➜  movi git:(feature/demand-prediction) ✗ python benchmark_demand_model.py --model demand_model_212_219_base.pth --test-dataset /media/yabir/datasets/yellow_tripdata_2015-12.feather --geofence nyc_geofence.geojson   
Dataset size: 4464

Test RMSE=0.3092, RMSE std=0.02421
(env) ➜  movi git:(feature/demand-prediction) ✗ 

(env) ➜  movi git:(feature/demand-prediction) ✗ python benchmark_demand_model.py --model demand_model_212_219_static.pth --test-dataset /media/yabir/datasets/yellow_tripdata_2015-12.feather --geofence nyc_geofence.geojson  
Dataset size: 4464

Test RMSE=0.2916, RMSE std=0.02385
(env) ➜  movi git:(feature/demand-prediction) ✗ 

(env) ➜  movi git:(feature/demand-prediction) ✗ python benchmark_demand_model.py --model demand_model_212_219_variable.pth --test-dataset /media/yabir/datasets/yellow_tripdata_2015-12.feather --geofence nyc_geofence.geojson  
Dataset size: 4464

Test RMSE=0.2923, RMSE std=0.02415

```

The results show that adding this planes produces a slightly better result and the difference between using the MOVI version and my version is "identical"

What I propose as pending tasks is to compare the results with the ones in the paper https://arxiv.org/pdf/1911.03441.pdf in a different pull request
